### PR TITLE
sign request with SHA256

### DIFF
--- a/ckanext/saml2auth/spconfig.py
+++ b/ckanext/saml2auth/spconfig.py
@@ -73,6 +73,7 @@ def get_config():
                     u'assertion_consumer_service': [base + acs_endpoint]
                 },
                 u'allow_unsolicited': True,
+                u'authn_requests_signed': True,
                 u'name_id_format': name_id_format,
                 u'want_response_signed': response_signed,
                 u'want_assertions_signed': assertion_signed,

--- a/ckanext/saml2auth/views/saml2auth.py
+++ b/ckanext/saml2auth/views/saml2auth.py
@@ -25,6 +25,7 @@ from saml2 import entity
 from saml2.authn_context import requested_authn_context
 from saml2.ident import code
 from saml2.saml import NameID
+from saml2.xmldsig import SIG_RSA_SHA256
 
 import ckan.plugins.toolkit as toolkit
 import ckan.model as model
@@ -343,9 +344,18 @@ def saml2login():
             comparison=comparison
         )
 
-        reqid, info = client.prepare_for_authenticate(requested_authn_context=final_context, relay_state=relay_state)
+        reqid, info = client.prepare_for_authenticate(
+            requested_authn_context=final_context,
+            relay_state=relay_state,
+            sign=True,
+            sigalg=SIG_RSA_SHA256
+        )
     else:
-        reqid, info = client.prepare_for_authenticate(relay_state=relay_state)
+        reqid, info = client.prepare_for_authenticate(
+            relay_state=relay_state,
+            sign=True,
+            sigalg=SIG_RSA_SHA256
+        )
 
     redirect_url = None
     for key, value in info[u'headers']:


### PR DESCRIPTION
For
https://github.com/GSA/data.gov/issues/5789#issuecomment-4121066815

- make the request signed
- signed with `sha256`. (default `sha1` does not work with login.gov)